### PR TITLE
Remove dead zone in mouse axis input

### DIFF
--- a/BasicTemplate/Content/Settings/Input Settings.json
+++ b/BasicTemplate/Content/Settings/Input Settings.json
@@ -1,7 +1,7 @@
 {
 	"ID": "f4c1c67842f6b745a6976aa8e7eff360",
 	"TypeName": "FlaxEditor.Content.Settings.InputSettings",
-	"EngineBuild": 6194,
+	"EngineBuild": 6215,
 	"Data": {
 	"ActionMappings": [
 		{
@@ -20,7 +20,7 @@
 			"Gamepad": 0,
 			"PositiveButton": 0,
 			"NegativeButton": 0,
-			"DeadZone": 1.0,
+			"DeadZone": 0.0,
 			"Sensitivity": 0.4,
 			"Gravity": 1.0,
 			"Scale": 1.0,
@@ -32,7 +32,7 @@
 			"Gamepad": 0,
 			"PositiveButton": 0,
 			"NegativeButton": 0,
-			"DeadZone": 1.0,
+			"DeadZone": 0.0,
 			"Sensitivity": 0.4,
 			"Gravity": 1.0,
 			"Scale": 1.0,

--- a/FirstPersonShooterTemplate/Content/Settings/Input Settings.json
+++ b/FirstPersonShooterTemplate/Content/Settings/Input Settings.json
@@ -1,7 +1,7 @@
 {
 	"ID": "f4c1c67842f6b745a6976aa8e7eff360",
 	"TypeName": "FlaxEditor.Content.Settings.InputSettings",
-	"EngineBuild": 6194,
+	"EngineBuild": 6215,
 	"Data": {
 	"ActionMappings": [
 		{
@@ -28,7 +28,7 @@
 			"Gamepad": 0,
 			"PositiveButton": 0,
 			"NegativeButton": 0,
-			"DeadZone": 1.0,
+			"DeadZone": 0.0,
 			"Sensitivity": 0.1,
 			"Gravity": 1.0,
 			"Scale": 1.0,
@@ -40,7 +40,7 @@
 			"Gamepad": 0,
 			"PositiveButton": 0,
 			"NegativeButton": 0,
-			"DeadZone": 1.0,
+			"DeadZone": 0.0,
 			"Sensitivity": 0.1,
 			"Gravity": 1.0,
 			"Scale": 1.0,

--- a/GraphicsFeaturesTour/Content/Settings/Input Settings.json
+++ b/GraphicsFeaturesTour/Content/Settings/Input Settings.json
@@ -1,7 +1,7 @@
 {
 	"ID": "f4c1c67842f6b745a6976aa8e7eff360",
 	"TypeName": "FlaxEditor.Content.Settings.InputSettings",
-	"EngineBuild": 6194,
+	"EngineBuild": 6215,
 	"Data": {
 	"ActionMappings": [
 		{
@@ -28,7 +28,7 @@
 			"Gamepad": 0,
 			"PositiveButton": 0,
 			"NegativeButton": 0,
-			"DeadZone": 1.0,
+			"DeadZone": 0.0,
 			"Sensitivity": 0.4,
 			"Gravity": 1.0,
 			"Scale": 1.0,
@@ -40,7 +40,7 @@
 			"Gamepad": 0,
 			"PositiveButton": 0,
 			"NegativeButton": 0,
-			"DeadZone": 1.0,
+			"DeadZone": 0.0,
 			"Sensitivity": 0.4,
 			"Gravity": 1.0,
 			"Scale": 1.0,

--- a/MaterialsFeaturesTour/Content/Settings/Input Settings.json
+++ b/MaterialsFeaturesTour/Content/Settings/Input Settings.json
@@ -1,7 +1,7 @@
 {
 	"ID": "f4c1c67842f6b745a6976aa8e7eff360",
 	"TypeName": "FlaxEditor.Content.Settings.InputSettings",
-	"EngineBuild": 6194,
+	"EngineBuild": 6215,
 	"Data": {
 	"ActionMappings": [
 		{
@@ -28,7 +28,7 @@
 			"Gamepad": 0,
 			"PositiveButton": 0,
 			"NegativeButton": 0,
-			"DeadZone": 1.0,
+			"DeadZone": 0.0,
 			"Sensitivity": 0.4,
 			"Gravity": 1.0,
 			"Scale": 1.0,
@@ -40,7 +40,7 @@
 			"Gamepad": 0,
 			"PositiveButton": 0,
 			"NegativeButton": 0,
-			"DeadZone": 1.0,
+			"DeadZone": 0.0,
 			"Sensitivity": 0.4,
 			"Gravity": 1.0,
 			"Scale": 1.0,

--- a/ParticlesFeaturesTour/Content/Settings/Input Settings.json
+++ b/ParticlesFeaturesTour/Content/Settings/Input Settings.json
@@ -1,7 +1,7 @@
 {
 	"ID": "f4c1c67842f6b745a6976aa8e7eff360",
 	"TypeName": "FlaxEditor.Content.Settings.InputSettings",
-	"EngineBuild": 6194,
+	"EngineBuild": 6215,
 	"Data": {
 	"ActionMappings": [
 		{
@@ -28,7 +28,7 @@
 			"Gamepad": 0,
 			"PositiveButton": 0,
 			"NegativeButton": 0,
-			"DeadZone": 1.0,
+			"DeadZone": 0.0,
 			"Sensitivity": 0.4,
 			"Gravity": 1.0,
 			"Scale": 1.0,
@@ -40,7 +40,7 @@
 			"Gamepad": 0,
 			"PositiveButton": 0,
 			"NegativeButton": 0,
-			"DeadZone": 1.0,
+			"DeadZone": 0.0,
 			"Sensitivity": 0.4,
 			"Gravity": 1.0,
 			"Scale": 1.0,

--- a/PhysicsFeaturesTour/Content/Settings/Input Settings.json
+++ b/PhysicsFeaturesTour/Content/Settings/Input Settings.json
@@ -1,7 +1,7 @@
 {
 	"ID": "f4c1c67842f6b745a6976aa8e7eff360",
 	"TypeName": "FlaxEditor.Content.Settings.InputSettings",
-	"EngineBuild": 6194,
+	"EngineBuild": 6215,
 	"Data": {
 	"ActionMappings": [
 		{
@@ -28,7 +28,7 @@
 			"Gamepad": 0,
 			"PositiveButton": 0,
 			"NegativeButton": 0,
-			"DeadZone": 1.0,
+			"DeadZone": 0.0,
 			"Sensitivity": 0.4,
 			"Gravity": 1.0,
 			"Scale": 1.0,
@@ -40,7 +40,7 @@
 			"Gamepad": 0,
 			"PositiveButton": 0,
 			"NegativeButton": 0,
-			"DeadZone": 1.0,
+			"DeadZone": 0.0,
 			"Sensitivity": 0.4,
 			"Gravity": 1.0,
 			"Scale": 1.0,


### PR DESCRIPTION
Slowly moving the mouse would not rotate the camera at all due to low sensitivity and dead zone values.

Preferably `Input.GetAxisRaw` should be used to read the mouse axis input to avoid this, but confusingly this same axis name is also used for controller input as well (maybe "Look X" and "Look Y" would be better names for these?).