### PR TITLE
Horizontally clip movement velocity

### DIFF
--- a/FirstPersonShooterTemplate/Source/FirstPersonShooter/PlayerScript.cs
+++ b/FirstPersonShooterTemplate/Source/FirstPersonShooter/PlayerScript.cs
@@ -114,7 +114,12 @@ public class PlayerScript : Script
 
         var velocity = new Vector3(inputH, 0.0f, inputV);
         velocity.Normalize();
-        velocity = CameraTarget.Transform.TransformDirection(velocity);
+
+        Vector3 Rotation = CameraTarget.LocalEulerAngles;
+        Rotation.X = 0;
+        Rotation.Z = 0;
+
+        velocity = Vector3.Transform(velocity, Quaternion.Euler(Rotation));
 
         if (PlayerController.IsGrounded)
         {


### PR DESCRIPTION
Currently, movement velocity gets transformed to the exact rotation of a camera, which results in movement slowdowns when you look up/down and try to walk. 
![image](https://user-images.githubusercontent.com/118038102/210154196-d3fce2dd-c1b2-446e-bc16-bc939e27e65b.png)
This pull fixes the issue by ignoring every other axis but the needed horizontal one.